### PR TITLE
fix(action): Add missing backslash to docker run command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
           -e INPUT_OPERATION="${{ inputs.OPERATION }}" \
           -e INPUT_WORKING_DIRECTORY="${{ inputs.WORKING_DIRECTORY }}" \
           -e INPUT_TIMEOUT="${{ inputs.TIMEOUT }}" \
-          -e INPUT_REGION="${{ inputs.REGION }}"
+          -e INPUT_REGION="${{ inputs.REGION }}" \
           -e SLACK_TOKEN="${{ inputs.SLACK_TOKEN }}" \
           -e SLACK_CHANNEL="${{ inputs.SLACK_CHANNEL }}" \
           -e LIVEKIT_URL="${{ env.LIVEKIT_URL }}" \


### PR DESCRIPTION
This PR fixes a bug introduced in #36 that causes the action to fail on startup.

A missing line-continuation character (`\`) was introduced in `action.yml`, which breaks the multi-line `docker run` command. This results in the following error:

```sh
docker: 'docker run' requires at least 1 argument.
```

This change adds the missing backslash, fixing the docker run command syntax.