### PR TITLE
fix: Update condition to ignore SECRET_LIST environment variable correctly]

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	for _, env := range os.Environ() {
 		if strings.HasPrefix(env, "SECRET_") {
 			// ignore the SECRET_LIST env var
-			if env == "SECRET_LIST" {
+			if strings.HasPrefix(env, "SECRET_LIST=") {
 				continue
 			}
 


### PR DESCRIPTION
This pull request contains a minor fix to the environment variable filtering logic in main.go. The change ensures that the code correctly ignores the SECRET_LIST environment variable by checking for its prefix rather than an exact match.

Currently, without this fix, the following error occurs when SECRET_LIST is not explicitly set:

```json
{"level":"info","ts":1764407579.6886115,"caller":"build/main.go:84","msg":"Loading secret","secret":"LIST"}
{"level":"debug","ts":1764407579.6886888,"logger":"cloud-agents-github-plugin","caller":"build/config.go:279","msg":"loading livekit.toml file"}
{"level":"error","ts":1764407580.5086393,"caller":"build/main.go:273","msg":"Failed to deploy agent","error":"twirp error internal: secret value cannot be empty","stacktrace":"main.deployAgent\n\t/build/main.go:273\nmain.main\n\t/build/main.go:154\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285"}
```

* Updated the condition to skip SECRET_LIST environment variable by checking for the SECRET_LIST= prefix instead of an exact string match in main.go.